### PR TITLE
Feature: ASCII STL

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -68,7 +68,7 @@ jobs:
           pip install rmesh[test] --find-links dist --force-reinstall
           cd crates/rmesh_python && pytest
       - name: pytest
-        if: ${{ !startsWith(matrix.platform.target, 'x86') && matrix.platform.target != 'ppc64' && matrix.platform.target != 'armv7' && matrix.platform.target != 's390x' && matrix.platform.target != 'ppc64le' }}
+        if: ${{ !startsWith(matrix.platform.target, 'x86') && matrix.platform.target != 'ppc64' && matrix.platform.target != 'armv7' && matrix.platform.target != 's390x' && matrix.platform.target != 'ppc64le' && matrix.platform.target != 'aarch64' }}
         uses: uraimo/run-on-arch-action@v2
         with:
           arch: ${{ matrix.platform.target }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -3,6 +3,11 @@
 #
 #    maturin generate-ci github --pytest --platform linux windows macos -m crates/rmesh_python/Cargo.toml
 #
+
+# Manual changes:
+# - removed `pip install pytest`, changed to `pip install rmesh[test]`
+# added architecture skips from armv7, s390x, ppc
+
 name: CI
 
 on:
@@ -60,8 +65,7 @@ jobs:
           set -e
           python3 -m venv .venv
           source .venv/bin/activate
-          pip install rmesh --find-links dist --force-reinstall
-          pip install pytest
+          pip install rmesh[test] --find-links dist --force-reinstall
           cd crates/rmesh_python && pytest
       - name: pytest
         if: ${{ !startsWith(matrix.platform.target, 'x86') && matrix.platform.target != 'ppc64' && matrix.platform.target != 'armv7' && matrix.platform.target != 's390x' && matrix.platform.target != 'ppc64le' }}
@@ -112,8 +116,7 @@ jobs:
           set -e
           python3 -m venv .venv
           source .venv/Scripts/activate
-          pip install rmesh --find-links dist --force-reinstall
-          pip install pytest
+          pip install rmesh[test] --find-links dist --force-reinstall
           cd crates/rmesh_python && pytest
 
   macos:
@@ -146,8 +149,7 @@ jobs:
           set -e
           python3 -m venv .venv
           source .venv/bin/activate
-          pip install rmesh --find-links dist --force-reinstall
-          pip install pytest
+          pip install rmesh[test] --find-links dist --force-reinstall
           cd crates/rmesh_python && pytest
 
   sdist:

--- a/crates/rmesh/src/creation.rs
+++ b/crates/rmesh/src/creation.rs
@@ -262,12 +262,13 @@ impl Plane {
             }
         }
 
-        // todo : this should probably be least squares?
+        // get the centroid of the points
         let centroid = points
             .iter()
             .fold(Vector3::zeros(), |acc, p| acc + p.coords)
             / points.len() as f64;
 
+        // calculate the covariance matrix with parallelism
         let covariance = points
             .par_iter()
             .map(|p| {
@@ -276,7 +277,7 @@ impl Plane {
             })
             .reduce(Matrix3::zeros, |a, b| a + b);
 
-        // Eigen decomposition for least squares plane fit
+        // eigen decomposition for least squares plane fit
         let eig = covariance.symmetric_eigen();
         let normal = eig.eigenvectors.column(0).normalize();
 

--- a/crates/rmesh/src/creation.rs
+++ b/crates/rmesh/src/creation.rs
@@ -47,7 +47,7 @@ pub fn create_box(extents: &[f64; 3]) -> Trimesh {
         (3, 4, 7),
     ];
 
-    // Directly create the Trimesh struct
+    // directly create the Trimesh
     Trimesh {
         vertices,
         faces,
@@ -286,7 +286,7 @@ impl Plane {
     /// -------------
     /// transform
     ///   The transformation matrix that moves from the XY plane to this plane.
-    pub fn to_plane(&self) -> Matrix4<f64> {
+    pub fn transform_to_2d(&self) -> Matrix4<f64> {
         // this transform aligns the vectors then offsets the origin
         align_vectors(self.normal, Vector3::z()).append_translation(&Vector3::new(
             -self.origin.x,
@@ -306,7 +306,7 @@ impl Plane {
     /// projected
     ///   The projected points in 2D space.
     pub fn to_2d(&self, points: &[Point3<f64>]) -> Vec<Point2<f64>> {
-        let transform = self.to_plane();
+        let transform = self.transform_to_2d();
         points
             .par_iter()
             .map(|p| {
@@ -316,8 +316,8 @@ impl Plane {
             .collect()
     }
 
-    /// Convert 2D points into 3D points by applying the inverse of the
-    /// transformation matrix defined by this object.
+    /// Convert 2D points into 3D points by applying the inverse
+    /// of the transformation matrix defined by this object.
     ///
     /// Parameters
     /// -------------
@@ -329,7 +329,7 @@ impl Plane {
     /// converted
     ///   The converted points in 3D space.
     pub fn to_3d(&self, points: &[Point2<f64>]) -> Vec<Point3<f64>> {
-        let transform = self.to_plane().try_inverse().unwrap();
+        let transform = self.transform_to_2d().try_inverse().unwrap();
         points
             .par_iter()
             .map(|p| {
@@ -382,28 +382,29 @@ pub fn align_vectors(a: Vector3<f64>, b: Vector3<f64>) -> Matrix4<f64> {
     Rotation3::from_axis_angle(&axis, angle).to_homogeneous()
 }
 
-/// Find an arbitrary vector that is perpendicular to the given
-/// 3D vector.
+/// Find an arbitrary vector that is perpendicular to a
+/// given 3D vector, or if the input vector is zero will
+/// return a zero vector.
 ///
 /// Parameters
 /// -------------
-/// v
+/// vec
 ///  The vector to find a perpendicular vector to.
 ///
 /// Returns
 /// -------------
 /// perpendicular
 ///   Any perpendicular vector to `v`.
-pub fn perpendicular(v: &Vector3<f64>) -> Vector3<f64> {
-    if v.norm() < f64::EPSILON {
+pub fn perpendicular(vec: &Vector3<f64>) -> Vector3<f64> {
+    if vec.norm() < f64::EPSILON {
         // a zero vector should return a zero vector
         Vector3::new(0.0, 0.0, 0.0)
-    } else if v.x.abs() > v.y.abs() {
+    } else if vec.x.abs() > vec.y.abs() {
         // if the x component is the largest, we can use the y and z components
-        Vector3::new(-v.z, 0.0, v.x).normalize()
+        Vector3::new(-vec.z, 0.0, vec.x).normalize()
     } else {
         // otherwise we can use the x and z components
-        Vector3::new(0.0, v.z, -v.y).normalize()
+        Vector3::new(0.0, vec.z, -vec.y).normalize()
     }
 }
 

--- a/crates/rmesh/src/exchange/obj.rs
+++ b/crates/rmesh/src/exchange/obj.rs
@@ -240,7 +240,7 @@ impl ObjMesh {
         let mut faces = ObjFaces::default();
 
         // we may have to triangulate 3D polygon faces as we go
-        // OBJ supports arbitrary polygons but we need to convert them to triangles
+        // OBJ supports arbitrary polygons but we need triangles
         let mut triangulator = Triangulator::new();
 
         for line in lines.iter() {

--- a/crates/rmesh/src/exchange/obj.rs
+++ b/crates/rmesh/src/exchange/obj.rs
@@ -214,10 +214,12 @@ impl ObjFaces {
 }
 
 pub struct ObjMesh {
-    // each line of the OBJ file parsed into a native type
-    // but not evaluated into a mesh
+    // the original indexed vertices from the OBJ file
     vertices: ObjVertices,
+    // the indexed faces from the OBJ file
     faces: ObjFaces,
+
+    // the original lines from the OBJ file just parsed from strings
     lines: Vec<ObjLine>,
 }
 

--- a/crates/rmesh/src/exchange/stl.rs
+++ b/crates/rmesh/src/exchange/stl.rs
@@ -1,4 +1,4 @@
-use anyhow::{Error, Result, anyhow};
+use anyhow::{Result, anyhow};
 use rayon::prelude::*;
 
 use crate::{attributes::LoadSource, mesh::Trimesh};

--- a/crates/rmesh/src/exchange/stl.rs
+++ b/crates/rmesh/src/exchange/stl.rs
@@ -1,36 +1,130 @@
-use anyhow::{Result, anyhow};
+use anyhow::{Error, Result, anyhow};
 use rayon::prelude::*;
 
 use crate::{attributes::LoadSource, mesh::Trimesh};
 
 pub struct BinaryStl {
     header: String,
-    triangles: Vec<BinaryStlTriangle>,
+    triangles: Vec<StlTriangle>,
 }
 #[repr(C, packed)]
 #[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
-struct BinaryStlTriangle {
+struct StlTriangle {
     pub normal: [f32; 3],
     pub vertices: [f32; 9],
     pub attributes: u16,
 }
+// The size of each triangle in bytes
+const STL_TRIANGLE_SIZE: usize = std::mem::size_of::<StlTriangle>();
 
 impl BinaryStl {
+    /// Parse a binary or ASCII STL file from the raw bytes. Note that binary STL files
+    /// must exactly match the size specified in the header, or they will be parsed as
+    /// ASCII STL files and error later.
+    ///
+    /// Parameters
+    /// ------------
+    /// bytes
+    ///   Raw bytes of the STL file.
+    ///
+    /// Returns
+    /// ------------
+    /// Result<Self>
+    ///   A Result containing the parsed STL file or an error.
     pub fn from_bytes(bytes: &[u8]) -> Result<Self> {
         if bytes.len() < 84 {
             return Err(anyhow::anyhow!("STL file too short"));
         }
 
         let header = String::from_utf8_lossy(&bytes[0..80]).trim().to_string();
-        // let triangle_count = u32::from_le_bytes(bytes[80..84].try_into().unwrap());
+        // the number of triangles is stored as a little-endian u32 at bytes 80-84
+        let triangle_count = u32::from_le_bytes(bytes[80..84].try_into().unwrap());
 
-        let triangles: &[BinaryStlTriangle] = bytemuck::try_cast_slice(&bytes[84..])
+        // if our passed bytes are not a
+        if bytes.len() != 84 + (triangle_count as usize) * STL_TRIANGLE_SIZE {
+            // this may be an ASCII STL file
+            return Self::parse_ascii_stl(bytes);
+            // return Err(anyhow::anyhow!("STL file size does not match header"));
+        }
+        // we are
+
+        let triangles: &[StlTriangle] = bytemuck::try_cast_slice(&bytes[84..])
             .map_err(|_e| anyhow!("Could not interpret bytes as STL triangles!"))?;
 
         Ok(Self {
             header,
             triangles: triangles.to_vec(),
         })
+    }
+
+    /// Parse an ASCII STL file.
+    fn parse_ascii_stl(bytes: &[u8]) -> Result<Self> {
+        let text = String::from_utf8_lossy(bytes);
+
+        let header = text
+            .lines()
+            .next()
+            .ok_or_else(|| anyhow!("STL file is empty"))?
+            .to_string();
+
+        // split the text into chunks between the `facet` and `endfacet` keywords
+        let chunks = text.split("facet").collect::<Vec<_>>();
+
+        //println!("chunks: {:?}", chunks.clone());
+
+        let triangles = chunks
+            .par_iter()
+            .map(|chunk| {
+                let mut normal = [0.0f32; 3];
+                let mut vertices = [0.0f32; 9];
+                let mut vertex_count = 0;
+
+                for line in chunk.lines() {
+                    let mut parts = line.split_whitespace();
+                    //println!("parts: {:?}", parts.clone().collect::<Vec<_>>());
+                    match parts.next() {
+                        Some("normal") => {
+                            // Handles: "facet normal x y z"
+                            for i in 0..3 {
+                                normal[i] = match parts.next().and_then(|v| v.parse().ok()) {
+                                    Some(val) => val,
+                                    None => return None,
+                                };
+                            }
+                        }
+                        Some("vertex") => {
+                            // Handles: "vertex x y z"
+                            if vertex_count >= 3 {
+                                break;
+                            }
+                            for i in 0..3 {
+                                vertices[vertex_count * 3 + i] =
+                                    match parts.next().and_then(|v| v.parse().ok()) {
+                                        Some(val) => val,
+                                        None => return None,
+                                    };
+                            }
+                            vertex_count += 1;
+                        }
+                        _ => {}
+                    }
+                }
+
+                if vertex_count == 3 {
+                    Some(StlTriangle {
+                        normal,
+                        vertices,
+                        attributes: 0,
+                    })
+                } else {
+                    None
+                }
+            })
+            .filter_map(|t| t)
+            .collect::<Vec<_>>();
+        //println!("triangles: {:?}", triangles.clone());
+
+        Ok(Self { header, triangles })
     }
 
     pub fn to_mesh(&self) -> Result<Trimesh> {
@@ -67,16 +161,24 @@ impl BinaryStl {
 #[cfg(test)]
 mod tests {
 
-    use super::*;
     use crate::exchange::{MeshFormat, load_mesh};
 
     #[test]
-    fn test_mesh_stl() {
+    fn test_mesh_binary_stl() {
         let stl_data = include_bytes!("../../../../test/data/unit_cube.STL");
 
         let mesh = load_mesh(stl_data, MeshFormat::STL).unwrap();
 
         assert_eq!(mesh.vertices.len(), 36);
         assert_eq!(mesh.faces.len(), 12);
+    }
+
+    #[test]
+    fn test_mesh_ascii_stl() {
+        let stl_data = include_bytes!("../../../../test/data/two_objects_mixed_case_names.stl");
+        let mesh = load_mesh(stl_data, MeshFormat::STL).unwrap();
+
+        //assert_eq!(mesh.vertices.len(), 36);
+        assert_eq!(mesh.faces.len(), 24);
     }
 }

--- a/crates/rmesh_macro/src/lib.rs
+++ b/crates/rmesh_macro/src/lib.rs
@@ -1,6 +1,6 @@
 use proc_macro::TokenStream;
-use quote::{quote, format_ident};
-use syn::{parse_macro_input, Attribute, ItemFn, ReturnType, Type};
+use quote::{format_ident, quote};
+use syn::{Attribute, ItemFn, ReturnType, Type, parse_macro_input};
 
 #[proc_macro_attribute]
 pub fn cache_access(_attr: TokenStream, item: TokenStream) -> TokenStream {
@@ -34,11 +34,6 @@ pub fn cache_access(_attr: TokenStream, item: TokenStream) -> TokenStream {
 
     TokenStream::from(expanded)
 }
-
-
-
-
-
 
 #[proc_macro]
 pub fn generate_inner_cache(_input: TokenStream) -> TokenStream {

--- a/crates/rmesh_macro/src/lib.rs
+++ b/crates/rmesh_macro/src/lib.rs
@@ -1,6 +1,6 @@
 use proc_macro::TokenStream;
-use quote::quote;
-use syn::{ItemFn, parse_macro_input};
+use quote::{quote, format_ident};
+use syn::{parse_macro_input, Attribute, ItemFn, ReturnType, Type};
 
 #[proc_macro_attribute]
 pub fn cache_access(_attr: TokenStream, item: TokenStream) -> TokenStream {
@@ -33,4 +33,65 @@ pub fn cache_access(_attr: TokenStream, item: TokenStream) -> TokenStream {
     };
 
     TokenStream::from(expanded)
+}
+
+
+
+
+
+
+#[proc_macro]
+pub fn generate_inner_cache(_input: TokenStream) -> TokenStream {
+    // Parse the file and extract functions with #[cache_access]
+    let source_code = include_str!("../../rmesh/src/mesh.rs"); // Adjust the path if needed
+    let syntax_tree = syn::parse_file(source_code).expect("Failed to parse file");
+
+    let mut fields = Vec::new();
+
+    for item in syntax_tree.items {
+        if let syn::Item::Fn(func) = item {
+            if has_cache_access(&func.attrs) {
+                if let Some(return_type) = extract_return_type(&func) {
+                    let field_name = format_ident!("{}", func.sig.ident);
+                    fields.push(quote! {
+                        #field_name: Option<#return_type>
+                    });
+                }
+            }
+        }
+    }
+
+    // Generate the InnerCache struct
+    let expanded = quote! {
+        #[derive(Default, Debug, Clone)]
+        pub struct InnerCache {
+            #(#fields),*
+        }
+    };
+
+    TokenStream::from(expanded)
+}
+
+/// Check if a function has the #[cache_access] attribute
+fn has_cache_access(attrs: &[syn::Attribute]) -> bool {
+    attrs.iter().any(|attr| {
+        if let Ok(_) = attr.parse_nested_meta(|meta| {
+            if meta.path.is_ident("cache_access") {
+                return Ok(());
+            }
+            Err(meta.error("Unexpected attribute"))
+        }) {
+            return true;
+        }
+        false
+    })
+}
+
+/// Extract the return type of a function
+fn extract_return_type(func: &ItemFn) -> Option<Type> {
+    if let ReturnType::Type(_, ty) = &func.sig.output {
+        Some(*ty.clone())
+    } else {
+        None
+    }
 }

--- a/crates/rmesh_python/pyproject.toml
+++ b/crates/rmesh_python/pyproject.toml
@@ -16,5 +16,8 @@ classifiers = [
 dynamic = ["version"]
 dependencies = ["numpy>=2.0"]
 
+[project.optional-dependencies]
+test = ["pytest", "trimesh"]
+
 [tool.maturin]
 features = ["pyo3/extension-module"]

--- a/crates/rmesh_python/pyproject.toml
+++ b/crates/rmesh_python/pyproject.toml
@@ -1,4 +1,6 @@
 [build-system]
+# make sure we build on the same numpy version range
+# as our install numpy version range
 requires = ["maturin>=1.8,<2.0",
             "numpy>=2.0"]
 build-backend = "maturin"

--- a/crates/rmesh_python/test/test_bench.py
+++ b/crates/rmesh_python/test/test_bench.py
@@ -1,0 +1,50 @@
+import os
+
+import rmesh
+import trimesh
+from io import BytesIO
+from timeit import timeit
+
+# where test models are stored
+_models = os.path.abspath(os.path.expanduser("~/trimesh/models"))
+
+
+def compare(file_data: bytes, file_type: str):
+    try:
+        # make sure we can load in both libraries before benchmarking
+        _r = rmesh.load_mesh(file_data=file_data, file_type=file_type)
+        _t = trimesh.load_mesh(file_obj=BytesIO(file_data), file_type=file_type)
+    except BaseException as E:
+        print(E)
+        return None
+
+    count = 1
+    tri = timeit(
+        stmt="trimesh.load_mesh(file_obj=BytesIO(file_data), file_type=file_type)",
+        setup="import trimesh; from io import BytesIO",
+        number=count,
+        globals={"file_data": file_data, "file_type": file_type},
+    )
+    rme = timeit(
+        stmt="rmesh.load_mesh(file_data=file_data, file_type=file_type)",
+        setup="import rmesh",
+        number=count,
+        globals={"file_data": file_data, "file_type": file_type},
+    )
+
+    return {"trimesh": tri / count, "rmesh": rme / count, "ratio": tri / rme}
+
+
+def test_both():
+    results = {}
+    for file_name in os.listdir(_models):
+        with open(os.path.join(_models, file_name), "rb") as f:
+            file_data = f.read()
+        file_type = trimesh.util.split_extension(file_name)
+
+        results[file_name] = compare(file_data=file_data, file_type=file_type)
+        print(file_name, results[file_name])
+
+
+if __name__ == "__main__":
+    test_both()

--- a/crates/rmesh_python/test/test_bench.py
+++ b/crates/rmesh_python/test/test_bench.py
@@ -5,8 +5,12 @@ import trimesh
 from io import BytesIO
 from timeit import timeit
 
-# where test models are stored
-_models = os.path.abspath(os.path.expanduser("~/trimesh/models"))
+# current working
+_cwd = os.path.abspath(os.path.expanduser(os.path.dirname(__file__)))
+# root of checkout
+_root = os.path.abspath(os.path.join(_cwd, "..", "..", ".."))
+# if trimesh was cloned next to rmesh
+_models = os.path.abspath(os.path.join(_root, "..", "trimesh", "models"))
 
 
 def compare(file_data: bytes, file_type: str):
@@ -20,13 +24,13 @@ def compare(file_data: bytes, file_type: str):
 
     count = 1
     tri = timeit(
-        stmt="trimesh.load_mesh(file_obj=BytesIO(file_data), file_type=file_type)",
+        stmt="len(trimesh.load_mesh(file_obj=BytesIO(file_data), file_type=file_type).vertices)",
         setup="import trimesh; from io import BytesIO",
         number=count,
         globals={"file_data": file_data, "file_type": file_type},
     )
     rme = timeit(
-        stmt="rmesh.load_mesh(file_data=file_data, file_type=file_type)",
+        stmt="len(rmesh.load_mesh(file_data=file_data, file_type=file_type).vertices)",
         setup="import rmesh",
         number=count,
         globals={"file_data": file_data, "file_type": file_type},
@@ -35,15 +39,40 @@ def compare(file_data: bytes, file_type: str):
     return {"trimesh": tri / count, "rmesh": rme / count, "ratio": tri / rme}
 
 
+def to_markdown(results: dict) -> str:
+    """ """
+    mark = [
+        "| File Name | `trimesh` | `rmesh` | Speedup |",
+        "|    --     |    --     |   --    |   --    |",
+    ]
+    mark.extend(
+        f"| {k} | {r['trimesh']:0.4f}s | {r['rmesh']:0.4f}s | {r['ratio']:0.2f}x |"
+        for k, r in results.items()
+    )
+
+    return "\n".join(mark)
+
+
 def test_both():
+    # if we didn't check out trimesh for the models corpus
+    if not os.path.exists(_models):
+        print(f"models not in expected location (`{_models}`), exiting!")
+        return
+
     results = {}
     for file_name in os.listdir(_models):
-        with open(os.path.join(_models, file_name), "rb") as f:
+        file_path = os.path.join(_models, file_name)
+        if not os.path.isfile(file_path):
+            continue
+        with open(file_path, "rb") as f:
             file_data = f.read()
         file_type = trimesh.util.split_extension(file_name)
 
-        results[file_name] = compare(file_data=file_data, file_type=file_type)
-        print(file_name, results[file_name])
+        if result := compare(file_data=file_data, file_type=file_type):
+            results[file_name] = result
+            print(file_name, result)
+
+    print(to_markdown(results))
 
 
 if __name__ == "__main__":

--- a/test/data/two_objects_mixed_case_names.stl
+++ b/test/data/two_objects_mixed_case_names.stl
@@ -1,0 +1,172 @@
+solid CubeExportedFromCAD
+   facet normal -1.000000e+00 -4.336808e-16 -0.000000e+00
+      outer loop
+         vertex 4.336809e-16 0.000000e+00 1.000000e+00
+         vertex 0.000000e+00 1.000000e+00 1.000000e+00
+         vertex 4.336809e-16 0.000000e+00 0.000000e+00
+      endloop
+   endfacet
+   facet normal -1.000000e+00 -4.336808e-16 0.000000e+00
+      outer loop
+         vertex 4.336809e-16 0.000000e+00 0.000000e+00
+         vertex 0.000000e+00 1.000000e+00 1.000000e+00
+         vertex 0.000000e+00 1.000000e+00 0.000000e+00
+      endloop
+   endfacet
+   facet normal -0.000000e+00 -1.000000e+00 -0.000000e+00
+      outer loop
+         vertex 1.000000e+00 0.000000e+00 1.000000e+00
+         vertex 4.336809e-16 0.000000e+00 1.000000e+00
+         vertex 1.000000e+00 0.000000e+00 0.000000e+00
+      endloop
+   endfacet
+   facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+      outer loop
+         vertex 1.000000e+00 0.000000e+00 0.000000e+00
+         vertex 4.336809e-16 0.000000e+00 1.000000e+00
+         vertex 4.336809e-16 0.000000e+00 0.000000e+00
+      endloop
+   endfacet
+   facet normal 1.000000e+00 0.000000e+00 0.000000e+00
+      outer loop
+         vertex 1.000000e+00 1.000000e+00 1.000000e+00
+         vertex 1.000000e+00 0.000000e+00 1.000000e+00
+         vertex 1.000000e+00 1.000000e+00 0.000000e+00
+      endloop
+   endfacet
+   facet normal 1.000000e+00 0.000000e+00 0.000000e+00
+      outer loop
+         vertex 1.000000e+00 1.000000e+00 0.000000e+00
+         vertex 1.000000e+00 0.000000e+00 1.000000e+00
+         vertex 1.000000e+00 0.000000e+00 0.000000e+00
+      endloop
+   endfacet
+   facet normal -0.000000e+00 1.000000e+00 0.000000e+00
+      outer loop
+         vertex 0.000000e+00 1.000000e+00 1.000000e+00
+         vertex 1.000000e+00 1.000000e+00 1.000000e+00
+         vertex 0.000000e+00 1.000000e+00 0.000000e+00
+      endloop
+   endfacet
+   facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+      outer loop
+         vertex 0.000000e+00 1.000000e+00 0.000000e+00
+         vertex 1.000000e+00 1.000000e+00 1.000000e+00
+         vertex 1.000000e+00 1.000000e+00 0.000000e+00
+      endloop
+   endfacet
+   facet normal 0.000000e+00 -0.000000e+00 1.000000e+00
+      outer loop
+         vertex 1.000000e+00 0.000000e+00 1.000000e+00
+         vertex 1.000000e+00 1.000000e+00 1.000000e+00
+         vertex 4.336809e-16 0.000000e+00 1.000000e+00
+      endloop
+   endfacet
+   facet normal 0.000000e+00 -0.000000e+00 1.000000e+00
+      outer loop
+         vertex 4.336809e-16 0.000000e+00 1.000000e+00
+         vertex 1.000000e+00 1.000000e+00 1.000000e+00
+         vertex 0.000000e+00 1.000000e+00 1.000000e+00
+      endloop
+   endfacet
+   facet normal -0.000000e+00 -0.000000e+00 -1.000000e+00
+      outer loop
+         vertex 1.000000e+00 1.000000e+00 0.000000e+00
+         vertex 1.000000e+00 0.000000e+00 0.000000e+00
+         vertex 0.000000e+00 1.000000e+00 0.000000e+00
+      endloop
+   endfacet
+   facet normal 0.000000e+00 0.000000e+00 -1.000000e+00
+      outer loop
+         vertex 0.000000e+00 1.000000e+00 0.000000e+00
+         vertex 1.000000e+00 0.000000e+00 0.000000e+00
+         vertex 4.336809e-16 0.000000e+00 0.000000e+00
+      endloop
+   endfacet
+endsolid
+solid TranslatedCubeExportedFromCAD
+   facet normal -1.000000e+00 -4.336808e-16 -0.000000e+00
+      outer loop
+         vertex 5.0e+00 0.000000e+00 1.000000e+00
+         vertex 5.0e+00 1.000000e+00 1.000000e+00
+         vertex 5.0e+00 0.000000e+00 0.000000e+00
+      endloop
+   endfacet
+   facet normal -1.000000e+00 -4.336808e-16 0.000000e+00
+      outer loop
+         vertex 5.0e+00 0.000000e+00 0.000000e+00
+         vertex 5.0e+00 1.000000e+00 1.000000e+00
+         vertex 5.0e+00 1.000000e+00 0.000000e+00
+      endloop
+   endfacet
+   facet normal -0.000000e+00 -1.000000e+00 -0.000000e+00
+      outer loop
+         vertex 6.000000e+00 0.000000e+00 1.000000e+00
+         vertex 5.0e+00 0.000000e+00 1.000000e+00
+         vertex 6.000000e+00 0.000000e+00 0.000000e+00
+      endloop
+   endfacet
+   facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+      outer loop
+         vertex 6.000000e+00 0.000000e+00 0.000000e+00
+         vertex 5.0e+00 0.000000e+00 1.000000e+00
+         vertex 5.0e+00 0.000000e+00 0.000000e+00
+      endloop
+   endfacet
+   facet normal 1.000000e+00 0.000000e+00 0.000000e+00
+      outer loop
+         vertex 6.000000e+00 1.000000e+00 1.000000e+00
+         vertex 6.000000e+00 0.000000e+00 1.000000e+00
+         vertex 6.000000e+00 1.000000e+00 0.000000e+00
+      endloop
+   endfacet
+   facet normal 1.000000e+00 0.000000e+00 0.000000e+00
+      outer loop
+         vertex 6.000000e+00 1.000000e+00 0.000000e+00
+         vertex 6.000000e+00 0.000000e+00 1.000000e+00
+         vertex 6.000000e+00 0.000000e+00 0.000000e+00
+      endloop
+   endfacet
+   facet normal -0.000000e+00 1.000000e+00 0.000000e+00
+      outer loop
+         vertex 5.000000e+00 1.000000e+00 1.000000e+00
+         vertex 6.000000e+00 1.000000e+00 1.000000e+00
+         vertex 5.000000e+00 1.000000e+00 0.000000e+00
+      endloop
+   endfacet
+   facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+      outer loop
+         vertex 5.000000e+00 1.000000e+00 0.000000e+00
+         vertex 6.000000e+00 1.000000e+00 1.000000e+00
+         vertex 6.000000e+00 1.000000e+00 0.000000e+00
+      endloop
+   endfacet
+   facet normal 0.000000e+00 -0.000000e+00 1.000000e+00
+      outer loop
+         vertex 6.000000e+00 0.000000e+00 1.000000e+00
+         vertex 6.000000e+00 1.000000e+00 1.000000e+00
+         vertex 5.0e+00 0.000000e+00 1.000000e+00
+      endloop
+   endfacet
+   facet normal 0.000000e+00 -0.000000e+00 1.000000e+00
+      outer loop
+         vertex 5.0e+00 0.000000e+00 1.000000e+00
+         vertex 6.000000e+00 1.000000e+00 1.000000e+00
+         vertex 5.000000e+00 1.000000e+00 1.000000e+00
+      endloop
+   endfacet
+   facet normal -0.000000e+00 -0.000000e+00 -1.000000e+00
+      outer loop
+         vertex 6.000000e+00 1.000000e+00 0.000000e+00
+         vertex 6.000000e+00 0.000000e+00 0.000000e+00
+         vertex 5.000000e+00 1.000000e+00 0.000000e+00
+      endloop
+   endfacet
+   facet normal 0.000000e+00 0.000000e+00 -1.000000e+00
+      outer loop
+         vertex 5.000000e+00 1.000000e+00 0.000000e+00
+         vertex 6.000000e+00 0.000000e+00 0.000000e+00
+         vertex 5.0e+00 0.000000e+00 0.000000e+00
+      endloop
+   endfacet
+endsolid


### PR DESCRIPTION
- parse ASCII STL files
- make an `ObjMesh` object public for the crowd that wants exact representation mapping. 
- probably switch faces to a vec to somewhat match parry, which uses `&[[u32; 3]]` although probably with `usize` instead of `u32`
- add an initial benchmarking script which compares against trimesh.
- add a `pip install rmesh[test]` extra for pytest